### PR TITLE
feat: Exposed dropdown directive from dropdown treeview component

### DIFF
--- a/projects/ngx-treeview2/src/lib/components/dropdown-treeview/dropdown-treeview.component.ts
+++ b/projects/ngx-treeview2/src/lib/components/dropdown-treeview/dropdown-treeview.component.ts
@@ -5,6 +5,7 @@ import {TreeviewConfig} from '../../models/treeview-config';
 import {TreeviewComponent} from '../treeview/treeview.component';
 import {TreeviewHeaderTemplateContext} from '../../models/treeview-header-template-context';
 import {TreeviewItemTemplateContext} from '../../models/treeview-item-template-context';
+import {DropdownDirective} from '../../directives/dropdown.directive';
 
 @Component({
   selector: 'ngx-dropdown-treeview',
@@ -20,6 +21,7 @@ export class DropdownTreeviewComponent {
   @Output() selectedChange = new EventEmitter<any[]>(true);
   @Output() filterChange = new EventEmitter<string>();
   @ViewChild(TreeviewComponent, { static: false }) treeviewComponent: TreeviewComponent;
+  @ViewChild(DropdownDirective, { static: false }) dropdownDirective: DropdownDirective;
   buttonLabel: string;
 
   constructor(

--- a/src/app/book/book.component.html
+++ b/src/app/book/book.component.html
@@ -67,14 +67,19 @@
               <input class="form-check-input" type="checkbox" [(ngModel)]="dropdownEnabled"> Enable/disable
             </label>
           </div>
+          <div>
+            <label class="form-check-label">
+              <input class="form-check-input" type="checkbox" [(ngModel)]="closeOnSelection"> Close dropdown on selection
+            </label>
+          </div>
           <div class="form-group form-inline">
             <label>buttonClass</label>
             <select class="form-control mx-sm-3" [(ngModel)]="buttonClass">
               <option *ngFor="let c of buttonClasses" [value]="c">{{c}}</option>
             </select>
           </div>
-          <ngx-dropdown-treeview [config]="config" [items]="items" [buttonClass]="buttonClass"
-            (selectedChange)="values = $event" [disabled]="!dropdownEnabled"
+          <ngx-dropdown-treeview #dropdownTreeview [config]="config" [items]="items" [buttonClass]="buttonClass"
+            (selectedChange)="onSelectedChange($event)" [disabled]="!dropdownEnabled"
             [ngxDisabledOnSelector]="'button.dropdown-toggle'" (filterChange)="onFilterChange($event)">
           </ngx-dropdown-treeview>
         </div>

--- a/src/app/book/book.component.ts
+++ b/src/app/book/book.component.ts
@@ -1,5 +1,5 @@
-import {Component, OnInit} from '@angular/core';
-import {TreeviewConfig, TreeviewItem} from 'ngx-treeview2';
+import {Component, OnInit, ViewChild} from '@angular/core';
+import {DropdownTreeviewComponent, TreeviewConfig, TreeviewItem} from 'ngx-treeview2';
 import {BookService} from './book.service';
 
 @Component({
@@ -33,6 +33,9 @@ export class BookComponent implements OnInit {
   ];
   buttonClass = this.buttonClasses[0];
 
+  @ViewChild('dropdownTreeview') dropdownTreeview: DropdownTreeviewComponent;
+  closeOnSelection = false;
+
   constructor(
     private service: BookService
   ) { }
@@ -43,5 +46,12 @@ export class BookComponent implements OnInit {
 
   onFilterChange(value: string): void {
     console.log('filter:', value);
+  }
+
+  onSelectedChange(event: any[]) {
+    this.values = event;
+    if (this.closeOnSelection) {
+      this.dropdownTreeview.dropdownDirective.close();
+    }
   }
 }


### PR DESCRIPTION
This PR [adds back the exposed dropdown directive](https://github.com/leovo2708/ngx-treeview/blob/a278b5f0ea186a469d60e2ec8963738dd5bafe99/src/lib/dropdown-treeview.component.ts) present in the library a few versions ago. This allows the manipulation of the dropdown programatically, such as closing it. Also added a demo for this functionality.

Closes #9 